### PR TITLE
Fix setRoundedCorner (_FillRoundCornerRect and _DrawRoundCornerLineBorder)

### DIFF
--- a/middleware/legato/library/src/gfx/legato/widget/legato_widget_skin_classic_common.c
+++ b/middleware/legato/library/src/gfx/legato/widget/legato_widget_skin_classic_common.c
@@ -70,12 +70,12 @@ void leDraw_2x1BevelBorder(leRect* rect,
                         rect->width - 1,
                         bottomOuterColor,
                         a);
-    
+
     leRenderer_VertLine(rect->x + rect->width - 1,
                         rect->y + 1,
                         rect->height - 1,
                         bottomOuterColor,
-                        a);               
+                        a);
 }
 
 void leDraw_1x2BevelBorder(leRect* rect,
@@ -103,7 +103,7 @@ void leDraw_1x2BevelBorder(leRect* rect,
                         rect->width - 2,
                         bottomInnerColor,
                         a);
-    
+
     leRenderer_VertLine(rect->x + rect->width - 2,
                         rect->y + 1,
                         rect->height - 3,
@@ -116,12 +116,12 @@ void leDraw_1x2BevelBorder(leRect* rect,
                         rect->width - 1,
                         bottomOuterColor,
                         a);
-    
+
     leRenderer_VertLine(rect->x + rect->width - 1,
                         rect->y,
                         rect->height - 2,
                         bottomOuterColor,
-                        a);               
+                        a);
 }
 
 void leDraw_2x2BevelBorder(leRect* rect,
@@ -163,7 +163,7 @@ void leDraw_2x2BevelBorder(leRect* rect,
                         rect->width - 2,
                         bottomInnerColor,
                         a);
-    
+
     leRenderer_VertLine(rect->x + rect->width - 2,
                         rect->y + 1,
                         rect->y + rect->height - 3,
@@ -176,7 +176,7 @@ void leDraw_2x2BevelBorder(leRect* rect,
                         rect->width - 1,
                         bottomOuterColor,
                         a);
-    
+
     leRenderer_VertLine(rect->x + rect->width - 1,
                         rect->y,
                         rect->height - 2,
@@ -190,51 +190,51 @@ void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
                                               uint32_t a)
 {
     leRect drawRect;
-    
+
     //Draw the center rectangle
     drawRect.x = rect->x + radius;
     drawRect.y = rect->y + radius;
     drawRect.width = rect->width - (radius * 2);
     drawRect.height = rect->height - (radius * 2);
-    
+
     leRenderer_RectFill(&drawRect, clr, a);
-    
+
     //Draw the top rectangle
     drawRect.x = rect->x + radius;
     drawRect.y = rect->y;
-    drawRect.width = rect->width - (radius * 2);
+    drawRect.width = rect->width - (radius * 2 + radius % 2);
     drawRect.height = radius;
-    
+
     leRenderer_RectFill(&drawRect, clr, a);
-    
+
     //Draw the bottom rectangle
     drawRect.x = rect->x + radius;
     drawRect.y = rect->y + rect->height - radius;
-    drawRect.width = rect->width - (radius * 2);
+    drawRect.width = rect->width - (radius * 2 + radius % 2);
     drawRect.height = radius;
-    
+
     leRenderer_RectFill(&drawRect, clr, a);
-    
+
     //Draw the left rectangle
     drawRect.x = rect->x;
     drawRect.y = rect->y + radius;
     drawRect.width = radius;
-    drawRect.height = rect->height - (radius * 2);
-    
+    drawRect.height = rect->height - (radius * 2 + radius % 2);
+
     leRenderer_RectFill(&drawRect, clr, a);
-    
+
     //Draw the right rectangle
     drawRect.x = rect->x + rect->width - radius;
     drawRect.y = rect->y + radius;
     drawRect.width = radius;
-    drawRect.height = rect->height - (radius * 2);
-    
-    leRenderer_RectFill(&drawRect, clr, a);   
-    
+    drawRect.height = rect->height - (radius * 2 + radius % 2);
+
+    leRenderer_RectFill(&drawRect, clr, a);
+
     //Draw the corners
     //Upper left
-    drawRect.x = rect->x;
-    drawRect.y = rect->y;
+    drawRect.x = rect->x + (radius / 2 + radius % 2);
+    drawRect.y = rect->y + (radius / 2 + radius % 2);
     drawRect.width = radius;
     drawRect.height = radius;
 
@@ -242,60 +242,54 @@ void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
                        90,
                        90,
                        radius,
-                       LE_FALSE,
+                       LE_TRUE,
                        clr,
-                       LE_ARC_SMOOTH_EDGE,
+                       LE_TRUE,
                        a);
-    
+
     //Upper right
-    drawRect.x = rect->x + rect->width - radius;
-    drawRect.y = rect->y;
+    drawRect.x = rect->x + rect->width - (3 * radius / 2 + 3 * radius % 2);
+    drawRect.y = rect->y + (radius / 2 + radius % 2);
     drawRect.width = radius;
     drawRect.height = radius;
-    
+
     leRenderer_ArcFill(&drawRect,
                        0,
                        90,
                        radius,
-                       LE_FALSE,
+                       LE_TRUE,
                        clr,
-                       LE_ARC_SMOOTH_EDGE,
+                       LE_TRUE,
                        a);
-    
+
     //Lower left
-    drawRect.x = rect->x;
-    drawRect.y = rect->y + rect->height - (radius * 2);
+    drawRect.x = rect->x + (radius / 2 + radius % 2);
+    drawRect.y = rect->y + rect->height - (3 * radius / 2 + 3 * radius % 2);
     drawRect.width = radius;
     drawRect.height = radius;
-    
-    //pnt.x = drawRect.x + radius;
-    //pnt.y = drawRect.y + radius;
-    
+
     leRenderer_ArcFill(&drawRect,
                        180,
                        90,
                        radius,
-                       LE_FALSE,
+                       LE_TRUE,
                        clr,
-                       LE_ARC_SMOOTH_EDGE,
+                       LE_TRUE,
                        a);
-    
+
     //Lower right
-    drawRect.x = rect->x + rect->width - radius;
-    drawRect.y = rect->y + rect->height - radius;
+    drawRect.x = rect->x + rect->width - (3 * radius / 2 + 3 * radius % 2);
+    drawRect.y = rect->y + rect->height - (3 * radius / 2 + 3 * radius % 2);
     drawRect.width = radius;
     drawRect.height = radius;
-    
-    //pnt.x = drawRect.x + radius;
-    //pnt.y = drawRect.y + radius;
-    
+
     leRenderer_ArcFill(&drawRect,
                        270,
                        90,
                        radius,
-                       LE_FALSE,
+                       LE_TRUE,
                        clr,
-                       LE_ARC_SMOOTH_EDGE,
+                       LE_TRUE,
                        a);
 }
 
@@ -312,26 +306,26 @@ void leWidget_SkinClassic_DrawBackground(leWidget* wgt,
         (wgt->style.borderType == LE_WIDGET_BORDER_NONE ||
          wgt->style.borderType == LE_WIDGET_BORDER_LINE))
     {
-        leWidget_SkinClassic_FillRoundCornerRect(&rect, 
+        leWidget_SkinClassic_FillRoundCornerRect(&rect,
                                                  clr,
                                                  wgt->style.cornerRadius,
                                                  alpha);
-    }    
+    }
     else
     {
         leRenderer_RectFill(&rect, clr, alpha);
     }
 }
 
-void leWidget_SkinClassic_DrawRoundCornerBackground(leWidget* wgt, 
+void leWidget_SkinClassic_DrawRoundCornerBackground(leWidget* wgt,
                                                     leColor clr,
                                                     uint32_t alpha)
 {
     leRect rect;
 
     wgt->fn->rectToScreen(wgt, &rect);
-    
-    leWidget_SkinClassic_FillRoundCornerRect(&rect, 
+
+    leWidget_SkinClassic_FillRoundCornerRect(&rect,
                                              clr,
                                              wgt->style.cornerRadius,
                                              alpha);
@@ -339,9 +333,9 @@ void leWidget_SkinClassic_DrawRoundCornerBackground(leWidget* wgt,
 
 void leWidget_SkinClassic_DrawStandardBackground(leWidget* wgt,
                                                  uint32_t alpha)
-{    
+{
     if(wgt->style.backgroundType == LE_WIDGET_BACKGROUND_FILL)
-    {    
+    {
         leWidget_SkinClassic_DrawBackground(wgt,
                                             leScheme_GetRenderColor(wgt->scheme, LE_SCHM_BASE),
                                             alpha);
@@ -354,93 +348,96 @@ void leWidget_SkinClassic_DrawRoundCornerLineBorder(const leRect* rect,
                                                     uint32_t a)
 {
     leRect drawRect;
-    
+
     //Draw the top line
     leRenderer_HorzLine(rect->x + radius,
                         rect->y,
-                        rect->width - (radius * 2),
+                        rect->width - (radius * 2 + radius % 2),
                         clr,
                         a);
-    
+
     //Draw the bottom line
     leRenderer_HorzLine(rect->x + radius,
                         rect->y + rect->height - 1,
-                        rect->width - (radius * 2),
+                        rect->width - (radius * 2 + radius % 2),
                         clr,
                         a);
-    
+
     //Draw the left line
     leRenderer_VertLine(rect->x,
                         rect->y + radius,
-                        rect->height - (radius * 2),
+                        rect->height - (radius * 2 + radius % 2),
                         clr,
                         a);
-    
+
     //Draw the right line
     leRenderer_VertLine(rect->x + rect->width - 1,
                         rect->y + radius,
-                        rect->height - (radius * 2),
+                        rect->height - (radius * 2 + radius % 2),
                         clr,
                         a);
-    
+
+    /* Fudge the radius to match the > 1 thickness of the arch */
+    radius = 33 * radius / 14;
+
     //Upper left
     drawRect.x = rect->x;
     drawRect.y = rect->y;
     drawRect.width = radius;
     drawRect.height = radius;
-    
+
     leRenderer_ArcFill(&drawRect,
                        90,
                        90,
                        1,
-                       LE_FALSE,
+                       LE_TRUE,
                        clr,
-                       LE_FALSE,
+                       LE_TRUE,
                        a);
-    
+
     //Upper right
     drawRect.x = rect->x + rect->width - radius;
     drawRect.y = rect->y;
     drawRect.width = radius;
     drawRect.height = radius;
-    
+
     leRenderer_ArcFill(&drawRect,
                        0,
                        90,
                        1,
-                       LE_FALSE,
+                       LE_TRUE,
                        clr,
-                       LE_FALSE,
+                       LE_TRUE,
                        a);
-    
+
     //Lower left
     drawRect.x = rect->x;
-    drawRect.y = rect->y + rect->height - (radius * 2);
+    drawRect.y = rect->y + rect->height - radius;
     drawRect.width = radius;
     drawRect.height = radius;
-    
+
     leRenderer_ArcFill(&drawRect,
                        180,
                        90,
                        1,
-                       LE_FALSE,
+                       LE_TRUE,
                        clr,
-                       LE_FALSE,
+                       LE_TRUE,
                        a);
-    
+
     //Lower right
     drawRect.x = rect->x + rect->width - radius;
     drawRect.y = rect->y + rect->height - radius;
     drawRect.width = radius;
     drawRect.height = radius;
-    
+
     leRenderer_ArcFill(&drawRect,
                        270,
                        90,
                        1,
-                       LE_FALSE,
+                       LE_TRUE,
                        clr,
-                       LE_FALSE,
+                       LE_TRUE,
                        a);
 }
 
@@ -454,7 +451,7 @@ void leWidget_SkinClassic_DrawLineBorder(const leRect* rect,
                         rect->height - 1,
                         clr,
                         a);
-                        
+
     // right line
     leRenderer_VertLine(rect->x + rect->width - 1,
                         rect->y + 1,
@@ -462,19 +459,19 @@ void leWidget_SkinClassic_DrawLineBorder(const leRect* rect,
                         clr,
                         a);
 
-    // top line                        
+    // top line
     leRenderer_HorzLine(rect->x,
                         rect->y,
                         rect->width,
                         clr,
-                        a);  
-                        
-    // bottom line                        
+                        a);
+
+    // bottom line
     leRenderer_HorzLine(rect->x,
                         rect->y + rect->height - 1,
                         rect->width,
                         clr,
-                        a);                
+                        a);
 }
 
 void leWidget_SkinClassic_Draw2x2BeveledBorder(const leRect* rect,
@@ -485,49 +482,49 @@ void leWidget_SkinClassic_Draw2x2BeveledBorder(const leRect* rect,
                                                uint32_t a)
 {
 
-    
+
     // left outer
     leRenderer_VertLine(rect->x,
                         rect->y + 1,
                         rect->height - 2,
                         leftUpOuter,
                         a);
-                        
+
     // left inner
     leRenderer_VertLine(rect->x + 1,
                         rect->y + 1,
                         rect->height - 2,
                         leftUpInner,
                         a);
-    
+
     // top outer
     leRenderer_HorzLine(rect->x,
                         rect->y,
                         rect->width - 1,
                         leftUpOuter,
                         a);
-                        
+
     // top inner
     leRenderer_HorzLine(rect->x + 1,
                         rect->y + 1,
                         rect->width - 2,
                         leftUpInner,
                         a);
-                        
+
     // right outer
     leRenderer_VertLine(rect->x + rect->width - 1,
                         rect->y + 1,
                         rect->height - 2,
                         bottomRightOuter,
                         a);
-                        
+
     // right inner
     leRenderer_VertLine(rect->x + rect->width - 2,
                         rect->y + 1,
                         rect->height - 2,
                         bottomRightInner,
                         a);
-    
+
     // bottom outer
     leRenderer_HorzLine(rect->x,
                         rect->y + rect->height - 1,
@@ -540,8 +537,8 @@ void leWidget_SkinClassic_Draw2x2BeveledBorder(const leRect* rect,
                         rect->width - 2,
                         bottomRightInner,
                         a);
-}                                           
-                                            
+}
+
 void leWidget_SkinClassic_Draw1x2BeveledBorder(const leRect* rect,
                                                leColor leftUp,
                                                leColor bottomRightOuter,
@@ -554,13 +551,13 @@ void leWidget_SkinClassic_Draw1x2BeveledBorder(const leRect* rect,
                         rect->height - 1,
                         leftUp,
                         a);
-                        
-    // top line                        
+
+    // top line
     leRenderer_HorzLine(rect->x,
                         rect->y,
                         rect->width - 1,
                         leftUp,
-                        a);  
+                        a);
 
     // right outer line
     leRenderer_VertLine(rect->x + rect->width - 1,
@@ -568,21 +565,21 @@ void leWidget_SkinClassic_Draw1x2BeveledBorder(const leRect* rect,
                         rect->height - 1,
                         bottomRightOuter,
                         a);
-                            
+
     // right inner line
     leRenderer_VertLine(rect->x + rect->width - 2,
                         rect->y + 1,
                         rect->height - 2,
                         bototmRightInner,
                         a);
-    
+
     // bottom outer
     leRenderer_HorzLine(rect->x,
                         rect->y + rect->height - 1,
                         rect->width,
                         bottomRightOuter,
                         a);
-    
+
     // bottom inner
     leRenderer_HorzLine(rect->x + 1,
                         rect->y + rect->height - 2,
@@ -674,12 +671,12 @@ void leWidget_SkinClassic_InvalidateBorderAreas(const leWidget* wgt)
 {
 	leRect rect, dmgRect;
 	int32_t width, height;
-	
+
 	if(wgt->style.borderType == LE_WIDGET_BORDER_NONE)
 	    return;
-	
+
 	wgt->fn->rectToScreen(wgt, &rect);
-	
+
 	if(wgt->style.borderType == LE_WIDGET_BORDER_LINE)
 	{
 	    if(rect.width == 0 || rect.height == 0)
@@ -691,7 +688,7 @@ void leWidget_SkinClassic_InvalidateBorderAreas(const leWidget* wgt)
 
 			return;
 		}
-	
+
 	    width = 1;
 	    height = 1;
 	}
@@ -703,14 +700,14 @@ void leWidget_SkinClassic_InvalidateBorderAreas(const leWidget* wgt)
 		if(rect.width <= 3 || rect.height <= 3)
 		{
 			wgt->fn->_damageArea(wgt, &rect);
-			
+
 			return;
         }
-        
+
         width = 2;
 	    height = 2;
 	}
-	
+
 	// left line
 	dmgRect.x = rect.x;
 	dmgRect.y = rect.y;

--- a/middleware/legato/library/src/gfx/legato/widget/legato_widget_skin_classic_common.c
+++ b/middleware/legato/library/src/gfx/legato/widget/legato_widget_skin_classic_common.c
@@ -194,15 +194,15 @@ void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
     //Draw the center rectangle
     drawRect.x = rect->x + radius;
     drawRect.y = rect->y + radius;
-    drawRect.width = rect->width - (radius * 2);
-    drawRect.height = rect->height - (radius * 2);
+    drawRect.width = rect->width - (radius * 2 - radius % 2);
+    drawRect.height = rect->height - (radius * 2 - radius % 2);
 
     leRenderer_RectFill(&drawRect, clr, a);
 
     //Draw the top rectangle
     drawRect.x = rect->x + radius;
     drawRect.y = rect->y;
-    drawRect.width = rect->width - (radius * 2 + radius % 2);
+    drawRect.width = rect->width - (radius * 2 - radius % 2);
     drawRect.height = radius;
 
     leRenderer_RectFill(&drawRect, clr, a);
@@ -210,7 +210,7 @@ void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
     //Draw the bottom rectangle
     drawRect.x = rect->x + radius;
     drawRect.y = rect->y + rect->height - radius;
-    drawRect.width = rect->width - (radius * 2 + radius % 2);
+    drawRect.width = rect->width - (radius * 2 - radius % 2);
     drawRect.height = radius;
 
     leRenderer_RectFill(&drawRect, clr, a);
@@ -219,7 +219,7 @@ void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
     drawRect.x = rect->x;
     drawRect.y = rect->y + radius;
     drawRect.width = radius;
-    drawRect.height = rect->height - (radius * 2 + radius % 2);
+    drawRect.height = rect->height - (radius * 2 - radius % 2);
 
     leRenderer_RectFill(&drawRect, clr, a);
 
@@ -227,7 +227,7 @@ void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
     drawRect.x = rect->x + rect->width - radius;
     drawRect.y = rect->y + radius;
     drawRect.width = radius;
-    drawRect.height = rect->height - (radius * 2 + radius % 2);
+    drawRect.height = rect->height - (radius * 2 - radius % 2);
 
     leRenderer_RectFill(&drawRect, clr, a);
 
@@ -248,7 +248,7 @@ void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
                        a);
 
     //Upper right
-    drawRect.x = rect->x + rect->width - (3 * radius / 2 + 3 * radius % 2);
+    drawRect.x = rect->x + rect->width - (3 * radius / 2);
     drawRect.y = rect->y + (radius / 2 + radius % 2);
     drawRect.width = radius;
     drawRect.height = radius;
@@ -264,7 +264,7 @@ void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
 
     //Lower left
     drawRect.x = rect->x + (radius / 2 + radius % 2);
-    drawRect.y = rect->y + rect->height - (3 * radius / 2 + 3 * radius % 2);
+    drawRect.y = rect->y + rect->height - (3 * radius / 2);
     drawRect.width = radius;
     drawRect.height = radius;
 
@@ -278,8 +278,8 @@ void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
                        a);
 
     //Lower right
-    drawRect.x = rect->x + rect->width - (3 * radius / 2 + 3 * radius % 2);
-    drawRect.y = rect->y + rect->height - (3 * radius / 2 + 3 * radius % 2);
+    drawRect.x = rect->x + rect->width - (3 * radius / 2 );
+    drawRect.y = rect->y + rect->height - (3 * radius / 2);
     drawRect.width = radius;
     drawRect.height = radius;
 
@@ -348,37 +348,38 @@ void leWidget_SkinClassic_DrawRoundCornerLineBorder(const leRect* rect,
                                                     uint32_t a)
 {
     leRect drawRect;
+    int fudge = radius / 12 + 1;
 
     //Draw the top line
-    leRenderer_HorzLine(rect->x + radius,
+    leRenderer_HorzLine(rect->x + radius - fudge,
                         rect->y,
-                        rect->width - (radius * 2 + radius % 2),
+                        rect->width - (radius * 2 - radius % 2) + fudge * 2,
                         clr,
                         a);
 
     //Draw the bottom line
-    leRenderer_HorzLine(rect->x + radius,
+    leRenderer_HorzLine(rect->x + radius - fudge,
                         rect->y + rect->height - 1,
-                        rect->width - (radius * 2 + radius % 2),
+                        rect->width - (radius * 2 - radius % 2) + fudge * 2,
                         clr,
                         a);
 
     //Draw the left line
     leRenderer_VertLine(rect->x,
-                        rect->y + radius,
-                        rect->height - (radius * 2 + radius % 2),
+                        rect->y + radius - fudge,
+                        rect->height - (radius * 2 - radius % 2) + fudge * 2,
                         clr,
                         a);
 
     //Draw the right line
     leRenderer_VertLine(rect->x + rect->width - 1,
-                        rect->y + radius,
-                        rect->height - (radius * 2 + radius % 2),
+                        rect->y + radius - fudge,
+                        rect->height - (radius * 2 - radius % 2) + fudge * 2,
                         clr,
                         a);
 
     /* Fudge the radius to match the > 1 thickness of the arch */
-    radius = 33 * radius / 14;
+    radius = 209 * radius / 100 + 4;
 
     //Upper left
     drawRect.x = rect->x;
@@ -396,10 +397,8 @@ void leWidget_SkinClassic_DrawRoundCornerLineBorder(const leRect* rect,
                        a);
 
     //Upper right
-    drawRect.x = rect->x + rect->width - radius;
+    drawRect.x = rect->x + rect->width - radius + radius % 2;
     drawRect.y = rect->y;
-    drawRect.width = radius;
-    drawRect.height = radius;
 
     leRenderer_ArcFill(&drawRect,
                        0,
@@ -412,9 +411,7 @@ void leWidget_SkinClassic_DrawRoundCornerLineBorder(const leRect* rect,
 
     //Lower left
     drawRect.x = rect->x;
-    drawRect.y = rect->y + rect->height - radius;
-    drawRect.width = radius;
-    drawRect.height = radius;
+    drawRect.y = rect->y + rect->height - radius + radius % 2;
 
     leRenderer_ArcFill(&drawRect,
                        180,
@@ -426,10 +423,8 @@ void leWidget_SkinClassic_DrawRoundCornerLineBorder(const leRect* rect,
                        a);
 
     //Lower right
-    drawRect.x = rect->x + rect->width - radius;
-    drawRect.y = rect->y + rect->height - radius;
-    drawRect.width = radius;
-    drawRect.height = radius;
+    drawRect.x = rect->x + rect->width - radius + radius % 2;
+    drawRect.y = rect->y + rect->height - radius + radius % 2;
 
     leRenderer_ArcFill(&drawRect,
                        270,

--- a/middleware/legato/library/src/gfx/legato/widget/legato_widget_skin_classic_common.h
+++ b/middleware/legato/library/src/gfx/legato/widget/legato_widget_skin_classic_common.h
@@ -143,6 +143,11 @@ void leWidget_SkinClassic_DrawStandardHybridBorder(leWidget* wgt,
 
 void leWidget_SkinClassic_InvalidateBorderAreas(const leWidget*);
 
+void leWidget_SkinClassic_FillRoundCornerRect(const leRect* rect,
+                                              leColor clr,
+                                              uint32_t radius,
+                                              uint32_t a);
+
 // DOM-IGNORE-END
 
 #endif /* LEGATO_WIDGET_SKIN_CLASSIC_COMMON_H */

--- a/middleware/legato/library/src/gfx/legato/widget/slider/legato_widget_slider_skin_classic.c
+++ b/middleware/legato/library/src/gfx/legato/widget/slider/legato_widget_slider_skin_classic.c
@@ -57,7 +57,7 @@ void _leSliderWidget_GetSlideAreaRect(leSliderWidget* sld, leRect* rect)
     leRect widgetRect;
 
     sld->fn->localRect(sld, &widgetRect);
-    
+
     if(sld->alignment == LE_ORIENTATION_VERTICAL)
     {
         scrollRect.width = widgetRect.width / 4;
@@ -83,31 +83,46 @@ void _leSliderWidget_GetHandleRect(leSliderWidget* sld, leRect* rect)
     leRect widgetRect;
 
     sld->fn->localRect(sld, &widgetRect);
-    
+
     val = sld->value - sld->min;
     max = sld->max - sld->min;
-    
+
     percent = lePercentWholeRounded(val, max);
-    
+
     _leSliderWidget_GetSlideAreaRect(sld, &scrollRect);
-    
+
     if(sld->alignment == LE_ORIENTATION_VERTICAL)
     {
         percent = lePercentOf(scrollRect.height, percent);
-        
+
         rect->x = widgetRect.x;
         rect->y = ((scrollRect.y + scrollRect.height) - percent) - (sld->grip / 2);
-        rect->width = widgetRect.width;
         rect->height = sld->grip;
+        if (sld->widget.style.cornerRadius > 0) {
+            rect->x += (sld->widget.rect.width - sld->grip) / 2;
+            rect->width = sld->grip;
+        }
+        else
+        {
+            rect->width = widgetRect.width;
+        }
     }
     else
     {
         percent = lePercentOf(scrollRect.width, percent);
-        
+
         rect->x = (scrollRect.x + percent) - (sld->grip / 2);
         rect->y = widgetRect.y;
         rect->width = sld->grip;
-        rect->height = widgetRect.height;
+        if (sld->widget.style.cornerRadius > 0)
+        {
+            rect->y += (sld->widget.rect.height - sld->grip) / 2;
+            rect->height = sld->grip;
+        }
+        else
+        {
+            rect->height = widgetRect.height;
+        }
     }
 }
 
@@ -135,7 +150,7 @@ static void nextState(leSliderWidget* sld)
                 paintState.alpha = sld->fn->getCumulativeAlphaAmount(sld);
             }
 #endif
-           
+
             if(sld->widget.style.backgroundType != LE_WIDGET_BACKGROUND_NONE)
             {
                 sld->widget.status.drawState = DRAW_BACKGROUND;
@@ -149,14 +164,14 @@ static void nextState(leSliderWidget* sld)
         {
             sld->widget.status.drawState = DRAW_BAR;
             sld->widget.drawFunc = (leWidget_DrawFunction_FnPtr)&drawBar;
-            
+
             return;
         }
         case DRAW_BAR:
         {
             sld->widget.status.drawState = DRAW_HANDLE;
             sld->widget.drawFunc = (leWidget_DrawFunction_FnPtr)&drawHandle;
-            
+
             return;
         }
         case DRAW_HANDLE:
@@ -165,10 +180,10 @@ static void nextState(leSliderWidget* sld)
             {
                 sld->widget.drawFunc = (leWidget_DrawFunction_FnPtr)&drawBorder;
                 sld->widget.status.drawState = DRAW_BORDER;
-                
+
                 return;
             }*/
-            
+
             sld->widget.status.drawState = DONE;
             sld->widget.drawFunc = NULL;
         }
@@ -192,15 +207,21 @@ static void drawBackground(leSliderWidget* sld)
 static void drawBar(leSliderWidget* sld)
 {
     leRect barRect;
-    
+
     _leSliderWidget_GetSlideAreaRect(sld, &barRect);
     leUtils_RectToScreenSpace((leWidget*)sld, &barRect);
 
     // fill bar area
-    leRenderer_RectFill(&barRect,
-                        leScheme_GetRenderColor(sld->widget.scheme, LE_SCHM_BACKGROUND),
-                        paintState.alpha);
-                 
+    if (sld->widget.style.cornerRadius > 0) {
+        leWidget_SkinClassic_FillRoundCornerRect(&barRect,
+                                                 leScheme_GetRenderColor(sld->widget.scheme, LE_SCHM_BACKGROUND),
+                                                 sld->widget.style.cornerRadius, paintState.alpha);
+    } else {
+        leRenderer_RectFill(&barRect,
+                            leScheme_GetRenderColor(sld->widget.scheme, LE_SCHM_BACKGROUND),
+                            paintState.alpha);
+    }
+
     // draw border
     if(sld->widget.style.borderType == LE_WIDGET_BORDER_LINE)
     {
@@ -217,22 +238,30 @@ static void drawBar(leSliderWidget* sld)
                                                   leScheme_GetRenderColor(sld->widget.scheme, LE_SCHM_HIGHLIGHTLIGHT),
                                                   paintState.alpha);
     }
-    
+
     nextState(sld);
 }
 
 static void drawHandle(leSliderWidget* sld)
 {
     leRect handleRect;
-    
+
     _leSliderWidget_GetHandleRect(sld, &handleRect);
     leUtils_RectToScreenSpace((leWidget*)sld, &handleRect);
 
     // fill handle area
-    leRenderer_RectFill(&handleRect,
-                        leScheme_GetRenderColor(sld->widget.scheme, LE_SCHM_BASE),
-                        paintState.alpha);
-    
+    if (sld->widget.style.cornerRadius > 0) {
+        leRenderer_CircleFill(&handleRect,
+                              1,
+                              leScheme_GetRenderColor(sld->widget.scheme, LE_SCHM_BASE),
+                              leScheme_GetRenderColor(sld->widget.scheme, LE_SCHM_BASE),
+                              paintState.alpha);
+    } else {
+        leRenderer_RectFill(&handleRect,
+                            leScheme_GetRenderColor(sld->widget.scheme, LE_SCHM_BASE),
+                            paintState.alpha);
+    }
+
     // draw handle border
     if(sld->widget.style.borderType == LE_WIDGET_BORDER_LINE)
     {
@@ -248,14 +277,14 @@ static void drawHandle(leSliderWidget* sld)
                                                   leScheme_GetRenderColor(sld->widget.scheme, LE_SCHM_SHADOW),
                                                   paintState.alpha);
     }
-    
+
     nextState(sld);
 }
 
 /*static void drawBorder(leSliderWidget* sld)
 {
     leWidget_SkinClassic_DrawStandardRaisedBorder((leWidget*)sld);
-    
+
     nextState(sld);
 }*/
 
@@ -265,11 +294,11 @@ void _leSliderWidget_Paint(leSliderWidget* sld)
     {
         nextState(sld);
     }
-    
+
     while(sld->widget.status.drawState != DONE)
     {
         sld->widget.drawFunc((leWidget*)sld);
-        
+
 #if LE_PREEMPTION_LEVEL == 2
         break;
 #endif


### PR DESCRIPTION
It's accomplished mostly through fudging, but it's a _whole_ lot better than what was there.  Also, I applied the rounded corner business to `legato_widget_slider_skin_classic.c` for my own use, and that is a separate commit.   If applied to a slider, the handle will be circular instead of a rectangle, and the background rectangle will have the rounded corners.